### PR TITLE
Stop processing query responses if we get one with an empty From field

### DIFF
--- a/lib/serfx/commands.rb
+++ b/lib/serfx/commands.rb
@@ -150,6 +150,10 @@ module Serfx
         header = read_data
         check_rpc_error!(header)
         ev = read_data
+
+        # Ignore responses with an empty From field
+        break if ev['From'].nil? || ev['From'].empty?
+
         if ev['Type'] == 'done'
           break
         else


### PR DESCRIPTION
This fixes a behavior change that started occurring in Serf 0.7.x where it's possible to receive responses with an empty From and/or Payload field. Per the reference implementation from Hashicorp, we should just stop processing queries:
https://github.com/hashicorp/serf/blob/0271ae846daf79e98880bacdc27e5c26aea3f395/command/query.go#L139-L150